### PR TITLE
Update .gitmodules to use https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "server"]
 	path = server
-	url = git@github.com:corda/node-server.git
+	url = https://github.com/corda/node-server.git


### PR DESCRIPTION
Useful when using the explorer inside a docker container as there is no need to configure ssh