### PR TITLE
ENT-8809 Node explorer does not start up on M1 Mac

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -25,7 +25,11 @@ if(process.platform === 'darwin' || process.platform === 'linux'){
 function startServer(port) {
   serverProcess = require('child_process')
     //.spawn('java', ['-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=y', '-jar', jarFile.substring(7)]);
-    .spawn('java', ['-jar', jarFile]);
+    .spawn('java', [
+    '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+    '--add-opens', 'java.base/java.time=ALL-UNNAMED',
+    '-jar', jarFile]);
 
     serverProcess.stdout.on('data', function (data) {
       console.log('Electron Server Log: ' + data);


### PR DESCRIPTION
The node explorer cannot be started on an OS where the users JDK is 16 or beyond. The default OS JDK on M1 Macs is currently JDK 19.

The underlying cause is the removal of the illegal access to Java modules (see https://www.baeldung.com/java-illegal-reflective-access).

The changes in this PR add --add-opens for each of the modules used by the server. We could change the server, but this was a simpler change and is supported across all JDKs.